### PR TITLE
Fetch invalidated widget on factory insert

### DIFF
--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -11,7 +11,7 @@
 // Use generic factory wrappers for widgets to use standardized JSON loading methods
 namespace
 {
-generic_factory<widget> widget_factory( "widgets" );
+generic_factory<widget> widget_factory( "widget" );
 } // namespace
 
 template<>
@@ -158,6 +158,7 @@ std::string enum_to_string<widget_var>( widget_var data )
 
 void widget::load( const JsonObject &jo, const std::string & )
 {
+    mandatory( jo, was_loaded, "id", id );
     optional( jo, was_loaded, "strings", _strings );
     optional( jo, was_loaded, "labels", _labels );
     optional( jo, was_loaded, "width", _width, 1 );
@@ -212,32 +213,51 @@ void widget::finalize()
     varlist.reserve( _vars.size() );
     std::copy( _vars.begin(), _vars.end(), varlist.end() );
     if( !varlist.empty() ) {
+        widget &thiswgt = *this;
         // Populate _widgets with children from vars/labels
         // TODO: Move this to a helper function outside finalize()
         for( unsigned int i = 0; i < varlist.size(); ++i ) {
             // Make child a copy of parent
-            widget child( *this );
+            widget child;
             // Give child widget id like parent_id_varname
-            child.id = string_id<widget>( string_format( "%s_%s", id.c_str(),
-                                          io::enum_to_string<widget_var>( varlist[i] ) ) );
+            child.id = widget_id( string_format( "%s_%s", thiswgt.id.c_str(),
+                                                 io::enum_to_string<widget_var>( varlist[i] ) ) );
+            child._arrange = thiswgt._arrange;
+            child._bp_id = thiswgt._bp_id;
+            child._fill = thiswgt._fill;
+            child._symbols = thiswgt._symbols;
+            child._var_max = thiswgt._var_max;
+            child._var_min = thiswgt._var_min;
+            child._width = thiswgt._width;
 
             // Child var/label come from vars/labels lists
             child._var = varlist[i];
-            child._label = _labels[i];
-            // Don't nest vars and labels from parent
-            child._vars.clear();
-            child._labels.clear();
+            child._label = thiswgt._labels[i];
 
             // Child style is the un-pluralized style of parent
-            if( _style == "graphs" ) {
+            if( thiswgt._style == "graphs" ) {
                 child._style = "graph";
             } else { // "numbers"
                 child._style = "number";
             }
-            // Append _widgets to be arranged by layout()
-            _widgets.emplace_back( child.id );
             // Ensure this child can be referenced by find_id in the factory
-            widget_factory.insert( child );
+            widget &tmp = widget_factory.insert( child );
+
+            // Append _widgets to be arranged by layout().
+            // For whatever reason, generic_factory::insert can invalidate the current object.
+            // Find the object again to properly emplace child id.
+            const std::vector<widget> &wlist = widget_factory.get_all();
+            auto iter = std::find_if( wlist.begin(), wlist.end(), [thiswgt]( const widget & w ) {
+                return w.id == thiswgt.id;
+            } );
+            if( iter != wlist.end() ) {
+                thiswgt = *iter;
+                thiswgt._widgets.emplace_back( tmp.id );
+            } else {
+                // There's a problem with the widget list
+                debugmsg( "Widget %s was dropped from widget_factory!", thiswgt.id.c_str() );
+                return;
+            }
         }
     }
 }

--- a/src/widget.h
+++ b/src/widget.h
@@ -89,28 +89,6 @@ class widget
     public:
         widget() = default;
         explicit widget( const widget_id &id ) : id( id ) {}
-        // Copy constructor
-        widget( const widget &wgt ) : widget( wgt.id ) {
-            _style = wgt._style;
-            _label = wgt._label;
-            _var = wgt._var;
-            _var_min = wgt._var_min;
-            _var_max = wgt._var_max;
-            _bp_id = wgt._bp_id;
-            _width = wgt._width;
-            _symbols = wgt._symbols;
-            _fill = wgt._fill;
-            _arrange = wgt._arrange;
-            // Not copied:
-            // _strings, _colors, _widgets, _vars, _labels ?
-        }
-        // With copy constructor defined, implicit copy assignment operator is deprecated
-        widget &operator=( const widget &wgt ) {
-            cata_assert( &wgt != this );
-            widget temp( wgt );
-            *this = std::move( temp );
-            return *this;
-        };
 
         // Attributes from JSON
         // ----


### PR DESCRIPTION
This took way too long to figure out! I feel dumb even thinking about it, haha.

Here's what's new:
- I removed the copy constructor. Even without copying the id, it was causing some serious problems with `widget_factory.finalize()`. It's hard to explain and I don't understand it fully, but it has something to do with the stored json being deferred and loading in a circular loop.
- I learned that `generic_factory::insert` can invalidate the current object! (Seriously!) The fix for this was to fetch the widget again after inserting the newly created widget. The variables from `this` can't be trusted past the insert, so we're assigning a temporary "this" in `thiswgt`.
- Minor change, but made the factory name singular so that messages show as "invalid widget id ..." instead of "invalid widgets id ..."

With this, there should be no more access violations (I hope!). If you get the chance, try it out and let me know if you find any issues.

Testing:
```
$ ASAN_OPTIONS=detect_odr_violation=1 MALLOC_CHECK_=2 tests/cata_test -d yes --rng-seed time "widget value strings"

22:12:16.208 INFO : Randomness seeded to: 1640747536
22:12:16.209 WARNING : opendir [./test_user_dir/sound/] failed with "No such file or directory".
22:12:16.210 WARNING : opendir [./test_user_dir/gfx/] failed with "No such file or directory".
22:12:16.211 WARNING : opendir [./test_user_dir/gfx/] failed with "No such file or directory".
22:12:16.212 INFO : Number of render drivers on your system: 3
22:12:16.212 INFO : Render driver: 0/opengl
22:12:16.212 INFO : Render driver: 1/opengles2
22:12:16.212 INFO : Render driver: 2/software
22:12:16.212 INFO : [options] C locale set to C
22:12:16.212 INFO : [options] C++ locale set to C
22:12:16.232 WARNING : opendir [./test_user_dir/mods/] failed with "No such file or directory".
22:12:22.626 WARNING : opendir [./test_user_dir/save/Test World 108169/mods] failed with "No such file or directory".
22:12:59.380 INFO : Starting the actual test at Tue Dec 28 22:12:59 2021
Filters: widget value strings
0.000 s: numeric values
0.000 s: widget value strings
0.000 s: graph values with bucket fill
0.000 s: widget value strings
0.000 s: graph values with pool fill
0.000 s: widget value strings
===============================================================================
All tests passed (44 assertions in 1 test case)


22:12:59.383 INFO : Ended test at Tue Dec 28 22:12:59 2021

22:12:59.383 INFO : The test took 0.00297299 seconds
22:12:59.383 INFO : Randomness seeded to: 1640747536
```