### PR TITLE
Use display cache to boost performance

### DIFF
--- a/src/display.h
+++ b/src/display.h
@@ -9,6 +9,36 @@
 class avatar;
 class Character;
 
+struct disp_overmap_cache {
+    private:
+        tripoint_abs_omt _center;
+        tripoint_abs_omt _mission;
+        std::string _om_wgt_str;
+
+    public:
+        disp_overmap_cache();
+
+        // Returns true if the stored overmap string can be used with the given
+        // center (player) position and mission target.
+        bool is_valid_for( const tripoint_abs_omt &center, const tripoint_abs_omt &mission ) const {
+            return _center == center && _mission == mission;
+        }
+
+        // Rebuild the cache using the validation parameters "center" and "mission"
+        // and store the associated widget string.
+        void rebuild( const tripoint_abs_omt &center, const tripoint_abs_omt &mission,
+                      const std::string &om_wgt_str ) {
+            _center = center;
+            _mission = mission;
+            _om_wgt_str = om_wgt_str;
+        }
+
+        // Retreive the cached widget string
+        const std::string &get_val() const {
+            return _om_wgt_str;
+        }
+};
+
 // The display namespace contains UI string output and colorization functions
 // Some return plain strings or translations, some return a (string, color) pair,
 // and some return a string with colorization tags embedded.


### PR DESCRIPTION
The overmap widget is looking great! The only issue is that the widget string gets rebuilt every few milliseconds, which is pretty expensive in this case.

Solution: Cache the overmap string to improve performance. As long as the player is in the same OMT and has the same active mission target, we can hit the cache instead of rebuilding the overmap every time. There's no sense in recalculating the same overmap string if it hasn't changed.

#### Before
![perf_before](https://user-images.githubusercontent.com/12537966/149420574-e6ac2609-3259-4c0d-b2ec-127aa1441f3b.png)

#### After
![perf_after](https://user-images.githubusercontent.com/12537966/149420605-65c10877-459e-4485-ab9a-0de14f558805.png)

(Retrieving the cached value makes the draw call basically free, which saves ~2% cpu load)

### Testing

<details>
<summary>Test results below:</summary>

```
$ tests/cata_test -d yes --rng-seed time "multi-line overmap text widget"

19:02:24.505 INFO : Randomness seeded to: 1642118544
19:02:24.506 WARNING : opendir [./test_user_dir/sound/] failed with "No such file or directory".
19:02:24.509 WARNING : opendir [./test_user_dir/gfx/] failed with "No such file or directory".
19:02:24.509 WARNING : opendir [./test_user_dir/gfx/] failed with "No such file or directory".
19:02:24.511 INFO : Number of render drivers on your system: 3
19:02:24.511 INFO : Render driver: 0/opengl
19:02:24.511 INFO : Render driver: 1/opengles2
19:02:24.511 INFO : Render driver: 2/software
19:02:24.511 INFO : [options] C locale set to C
19:02:24.511 INFO : [options] C++ locale set to C
19:02:24.546 WARNING : opendir [./test_user_dir/mods/] failed with "No such file or directory".
19:02:38.291 WARNING : opendir [./test_user_dir/save/Test World 22320/mods] failed with "No such file or directory".
19:03:55.885 INFO : Starting the actual test at Thu Jan 13 19:03:55 2022
Filters: multi-line overmap text widget
0.000 s: field
0.205 s: multi-line overmap text widget
0.000 s: forest
0.102 s: multi-line overmap text widget
0.000 s: central lab
0.102 s: multi-line overmap text widget
===============================================================================
All tests passed (3 assertions in 1 test case)


19:03:56.299 INFO : Ended test at Thu Jan 13 19:03:56 2022

19:03:56.300 INFO : The test took 0.41431 seconds
19:03:56.300 INFO : Randomness seeded to: 1642118544
```

</details>

<hr>

P.S.: I modified the test to update the overmap cache for each section. Since the avatar doesn't move, I just assigned a mission and moved the mission target.